### PR TITLE
migrations: Enforce that they must be backwards compatible.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,8 @@ jobs:
         - 5432:5432
     steps:
     - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
@@ -43,3 +45,10 @@ jobs:
       run: |
         cd vaccinate
         pytest
+    - name: Check migrations are backwards-compatible
+      env:
+        DJANGO_SECRET_KEY: secret for running tests
+        SOCIAL_AUTH_AUTH0_SECRET: auth0-secret-would-go-here
+        DATABASE_URL: postgres://postgres:postgres@127.0.0.1:${{ job.services.postgres.ports['5432'] }}/vaccinate
+      run: |
+        ./vaccinate/manage.py lintmigrations --project-root-path ./vaccinate 7aefb8cb6c19968ba7b97fdd099ccdd224e756f1

--- a/requirements.in
+++ b/requirements.in
@@ -14,6 +14,9 @@ whitenoise
 # PostgreSQL backend
 psycopg2-binary
 
+# Verify that migrations are backwards compatable
+django-migration-linter
+
 # Easy reconfiguration of
 dj-database-url
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,9 @@
 appdirs==1.4.4 \
     --hash=sha256:7d5d0167b2b1ba821647616af46a749d1c653740dd0d2415100fe26e27afdf41 \
     --hash=sha256:a841dacd6b99318a741b166adb07e19ee71a274450e68237b4650ca1055ab128
-    # via black
+    # via
+    #   black
+    #   django-migration-linter
 asgiref==3.3.1 \
     --hash=sha256:5ee950735509d04eb673bd7f7120f8fa1c9e2df495394992c73234d526907e17 \
     --hash=sha256:7162a3cb30ab0609f1a4c95938fd73e8604f63bdba516a7f7d64b83ff09478f0
@@ -100,10 +102,16 @@ dj-database-url==0.5.0 \
     --hash=sha256:4aeaeb1f573c74835b0686a2b46b85990571159ffc21aa57ecd4d1e1cb334163 \
     --hash=sha256:851785365761ebe4994a921b433062309eb882fedd318e1b0fcecc607ed02da9
     # via -r requirements.in
+django-migration-linter==2.5.1 \
+    --hash=sha256:32f552b09e122c278acbef84d92c2f01ecf03dfa0c72b4918762b7e39f598691 \
+    --hash=sha256:e4209e74393ddb86f31e8b7a13555fcecd1def506a04e1fe16b470248661dec7
+    # via -r requirements.in
 django==3.1.7 \
     --hash=sha256:32ce792ee9b6a0cbbec340123e229ac9f765dff8c2a4ae9247a14b2ba3a365a7 \
     --hash=sha256:baf099db36ad31f970775d0be5587cc58a6256a6771a44eb795b554d45f211b8
-    # via -r requirements.in
+    # via
+    #   -r requirements.in
+    #   django-migration-linter
 ecdsa==0.14.1 \
     --hash=sha256:64c613005f13efec6541bb0a33290d0d03c27abab5f15fbab20fb0ee162bdd8e \
     --hash=sha256:e108a5fe92c67639abae3260e43561af914e7fd0d27bae6d2ec1312ae7934dfe
@@ -352,6 +360,7 @@ six==1.15.0 \
     --hash=sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259 \
     --hash=sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced
     # via
+    #   django-migration-linter
     #   ecdsa
     #   python-dateutil
     #   python-jose

--- a/vaccinate/config/settings.py
+++ b/vaccinate/config/settings.py
@@ -79,6 +79,7 @@ INSTALLED_APPS = [
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.staticfiles",
+    "django_migration_linter",
     "social_django",
     "auth0login",
     "core",


### PR DESCRIPTION
Since migrations may happen while traffic is still being served by the
previous version, it is important that they be backwards-compatible;
that is, no column or table drops or renames unless production has
already stopped relying on them.

Add a linter which validates this property.  Since there have
_already_ been non-backwards-compatible changes (which were fine, it's
only going forward that matters!), we pass it a "high water mark" of
a recent commit on main; only migrations after that point are checked.

Because this relies on commit history in CI, it requires a non-shallow
clone in the github checkout action.  Particularly for small
repositories, shallow clones are significantly more CPU intensive, for
only tiny gain; switching to a deep clone is not a notable cost.