### PR TITLE
deploy: Disable gunicorn timeouts, use recommended settings.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,5 +23,5 @@ WORKDIR $APP_HOME/vaccinate
 # despite `collectstatic` not caring what they are.
 RUN DJANGO_SECRET_KEY=1 SOCIAL_AUTH_AUTH0_SECRET= ./manage.py collectstatic --no-input
 
-CMD exec gunicorn -c config/gunicorn.py -b :$PORT config.wsgi
+CMD exec gunicorn -c config/gunicorn.py --workers 1 --threads 8 --timeout 0 --preload -b :$PORT config.wsgi
 


### PR DESCRIPTION
Per the Cloud Run suggested settings, "disable the timeouts of the
workers to allow Cloud Run to handle instance scaling."[1]

This should address issues with longer request times.

[1] https://cloud.google.com/run/docs/quickstarts/build-and-deploy#python_1