### PR TITLE
api: Catch and log requests even for exceptions.

### DIFF
--- a/vaccinate/api/utils.py
+++ b/vaccinate/api/utils.py
@@ -2,8 +2,9 @@ import datetime
 import json
 import secrets
 from functools import wraps
+from typing import Optional
 
-from django.http import JsonResponse
+from django.http import HttpResponseServerError, JsonResponse
 from django.utils import timezone
 
 from .models import ApiKey, ApiLog
@@ -44,35 +45,42 @@ def require_api_key(view_fn):
 def log_api_requests(view_fn):
     @wraps(view_fn)
     def replacement_view_function(request, *args, **kwargs):
+        response: Optional[HttpResponse] = None
         on_request_logged = []
         kwargs["on_request_logged"] = on_request_logged.append
-        response = view_fn(request, *args, **kwargs)
-        # Create the log record
-        post_body = None
-        post_body_json = None
-        response_body = None
-        response_body_json = None
-        if request.method == "POST":
-            try:
-                post_body_json = json.loads(request.body)
-            except ValueError:
-                post_body = request.body
         try:
-            response_body_json = json.loads(response.content)
-        except ValueError:
-            response_body = response.content
-        log = ApiLog.objects.create(
-            method=request.method,
-            path=request.path,
-            query_string=request.META.get("QUERY_STRING") or "",
-            remote_ip=request.META.get("REMOTE_ADDR") or "",
-            post_body=post_body,
-            post_body_json=post_body_json,
-            response_status=response.status_code,
-            response_body=response_body,
-            response_body_json=response_body_json,
-            api_key=getattr(request, "api_key", None) or None,
-        )
+            response = view_fn(request, *args, **kwargs)
+        finally:
+            if response is None:
+                response = HttpResponseServerError()
+            # Create the log record
+            post_body = None
+            post_body_json = None
+            response_body = None
+            response_body_json = None
+            if request.method == "POST":
+                try:
+                    post_body_json = json.loads(request.body)
+                except ValueError:
+                    post_body = request.body
+            try:
+                response_body_json = json.loads(response.content)
+            except ValueError:
+                response_body = response.content
+            log = ApiLog.objects.create(
+                method=request.method,
+                path=request.path,
+                query_string=request.META.get("QUERY_STRING") or "",
+                remote_ip=request.META.get("REMOTE_ADDR") or "",
+                post_body=post_body,
+                post_body_json=post_body_json,
+                response_status=response.status_code,
+                response_body=response_body,
+                response_body_json=response_body_json,
+                api_key=getattr(request, "api_key", None) or None,
+            )
+
+        # If the request was _successful_, we go on to call the callbacks.
         for callback in on_request_logged:
             callback(log)
         return response


### PR DESCRIPTION
Failures of the view function that raise exceptions should
_especially_ have their payload caught.  While this is already
nominally done in Sentry, having it all in one place is advantageous.
