### PR TITLE
sentry: Ignore all SuspiciousOperation loggers

### DIFF
--- a/vaccinate/config/settings.py
+++ b/vaccinate/config/settings.py
@@ -5,6 +5,7 @@ import dj_database_url
 import sentry_sdk
 from django.conf.locale.en import formats as en_formats
 from sentry_sdk.integrations.django import DjangoIntegration
+from sentry_sdk.integrations.logging import ignore_logger
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -29,6 +30,23 @@ if SENTRY_DSN:
         environment=os.environ.get("DEPLOY", "unknown"),
         release=os.environ.get("COMMIT_SHA", None),
     )
+    # Ignore all of the loggers from django.security that are for user
+    # errors; see https://docs.djangoproject.com/en/3.1/ref/exceptions/#suspiciousoperation
+    IGNORE_LOGGERS = [
+        "django.security.SuspiciousOperation",
+        "django.security.DisallowedHost",
+        "django.security.DisallowedModelAdminLookup",
+        "django.security.DisallowedModelAdminToField",
+        "django.security.DisallowedRedirect",
+        "django.security.InvalidSessionKey",
+        "django.security.RequestDataTooBig",
+        "django.security.SuspiciousFileOperation",
+        "django.security.SuspiciousMultipartForm",
+        "django.security.SuspiciousSession",
+        "django.security.TooManyFieldsSent",
+    ]
+    for logger in IGNORE_LOGGERS:
+        ignore_logger(logger)
 
 # Auth0
 SOCIAL_AUTH_TRAILING_SLASH = False


### PR DESCRIPTION
"SuspiciousOperation" exceptions all return a 400 to the user when
they bubble up[1], and all of them are uninteresting to Sentry.  While
they may, in bulk, show a mis-configuration of some sort of the
application, such a failure should be detected via the increase in
400's, not via these, which are uninteresting individually.

While all of these are subclasses of SuspiciousOperation, we enumerate
them explicitly for a number of reasons:

 - There is no one logger we can ignore that captures all of them.
   Each of the errors uses its own logger, and django does not supply
   a `django.security` logger that all of them feed into.

 - Nor can we catch this by examining the exception object.  The
   SuspiciousOperation exception is raised too early in the stack for
   us to catch the exception by way of middleware and check
   `isinstance`.  But at the Sentry level, in `add_context`, it is no
   longer an exception but a log entry, and as such we have no
   `isinstance` that can be applied; we only know the logger name.

 - Finally, there is the semantic argument that while we have decided
   to ignore this set of security warnings, we _may_ wish to log new
   ones that may be added at some point in the future.  It is better
   to opt into those ignores than to blanket ignore all messages from
   the security logger.

[1] https://docs.djangoproject.com/en/3.1/ref/exceptions/#suspiciousoperation