### PR TITLE
admin: Remove a duplicate class.

### DIFF
--- a/vaccinate/core/admin.py
+++ b/vaccinate/core/admin.py
@@ -7,7 +7,7 @@ from django.utils import timezone
 from django.utils.html import escape
 from django.utils.safestring import mark_safe
 from reversion.models import Revision, Version
-from reversion_compare.admin import CompareVersionAdmin as VersionAdmin
+from reversion_compare.admin import CompareVersionAdmin
 
 from .admin_actions import export_as_csv_action
 from .models import (
@@ -62,7 +62,7 @@ class ProviderAdmin(DynamicListDisplayMixin, admin.ModelAdmin):
 
 
 @admin.register(County)
-class CountyAdmin(DynamicListDisplayMixin, VersionAdmin):
+class CountyAdmin(DynamicListDisplayMixin, CompareVersionAdmin):
     save_on_top = True
     search_fields = ("name",)
     list_display = ("name", "state", "fips_code")
@@ -154,7 +154,7 @@ class LocationDeletedFilter(admin.SimpleListFilter):
 
 
 @admin.register(Location)
-class LocationAdmin(DynamicListDisplayMixin, VersionAdmin):
+class LocationAdmin(DynamicListDisplayMixin, CompareVersionAdmin):
     save_on_top = True
     actions = [export_as_csv_action()]
 


### PR DESCRIPTION
VersionAdmin was both explicitly declared in this class (as the
configuration for the Version object in the admin) as well as the
mixin to make Counties and Locations have history.

Remove the aliasing in the import to remove the collision.