### PR TITLE
API: Latest report for Scooby should never include skips.

### DIFF
--- a/vaccinate/api/views.py
+++ b/vaccinate/api/views.py
@@ -325,10 +325,7 @@ def request_call(request, on_request_logged):
             )
         location = request.location
 
-    try:
-        latest_report = location.reports.order_by("-created_at")[0]
-    except IndexError:
-        latest_report = None
+    latest_report = location.dn_latest_non_skip_report
 
     county_record = {}
     county_age_floor_without_restrictions = []


### PR DESCRIPTION
Use the newly-denormalized field to get the latest non-flagged skip
report to show to Scooby.