### PR TITLE
Bring back reports history on locations

### DIFF
--- a/vaccinate/core/admin.py
+++ b/vaccinate/core/admin.py
@@ -197,6 +197,7 @@ class LocationAdmin(DynamicListDisplayMixin, CompareVersionAdmin):
             },
         ),
         ("Actions", {"fields": ("request_a_call", "scooby_report_link")}),
+        ("Reports", {"fields": ("reports_history",)}),
         (
             "Advanced Actions",
             {
@@ -220,6 +221,13 @@ class LocationAdmin(DynamicListDisplayMixin, CompareVersionAdmin):
                     "airtable_id",
                     "import_ref",
                     "import_json",
+                    "dn_latest_report",
+                    "dn_latest_report_including_pending",
+                    "dn_latest_yes_report",
+                    "dn_latest_skip_report",
+                    "dn_latest_non_skip_report",
+                    "dn_skip_report_count",
+                    "dn_yes_report_count",
                 ),
             },
         ),


### PR DESCRIPTION
Accidentally removed this in 89b0de8e622cc4b1123f07105cea5750dfb5d044

<img width="755" alt="image" src="https://user-images.githubusercontent.com/91915/114598121-63be6d00-9c46-11eb-85f4-1230b44322e5.png">
