### PR TITLE
set type="button" to scooby link so it opens correctly inside a form

### DIFF
--- a/vaccinate/core/admin.py
+++ b/vaccinate/core/admin.py
@@ -357,7 +357,7 @@ class LocationAdmin(DynamicListDisplayMixin, CompareVersionAdmin):
     def scooby_report_link(self, obj):
         if settings.SCOOBY_URL:
             return mark_safe(
-                '<a href="{}?location_id={}" target="_blank"><button class="primary-button">File report</button></a>'.format(
+                '<a href="{}?location_id={}" target="_blank"><button type="button" class="primary-button">File report</button></a>'.format(
                     settings.SCOOBY_URL, obj.public_id
                 )
             )


### PR DESCRIPTION
Fixes report in discord from Yaakov. A button inside a form assumes it is for form submission (and defaults to type="submit"). We have to set type=button on it so it knows it is not for that.