### PR TITLE
Resolves #320: associate reports with call requests.

### DIFF
--- a/vaccinate/api/test_submit_report.py
+++ b/vaccinate/api/test_submit_report.py
@@ -118,6 +118,7 @@ def test_submit_report_api_example(
     report = Report.objects.order_by("-id")[0]
     assert response.json()["created"] == [report.public_id]
     assert report.pid == response.json()["created"][0]
+    assert report.call_request == call_request
     expected_field_values = Report.objects.filter(pk=report.pk).values(
         *list(fixture["expected_fields"].keys())
     )[0]

--- a/vaccinate/api/views.py
+++ b/vaccinate/api/views.py
@@ -221,6 +221,11 @@ def submit_report(request, on_request_logged):
         completed=True, completed_at=timezone.now()
     )
 
+    # If this was based on a call request, associate it with the report
+    if existing_call_request:
+        report.call_request = existing_call_request
+        report.save()
+
     # Handle skip requests
     # Only check if "Do not call until is set"
     if report_data["do_not_call_until"] is not None:

--- a/vaccinate/core/models.py
+++ b/vaccinate/core/models.py
@@ -601,6 +601,9 @@ class Report(models.Model):
         # Used by the admin list view
         return ", ".join(t.name for t in self.availability_tags.all())
 
+    def based_on_call_request(self):
+        return self.call_request is not None
+
     class Meta:
         db_table = "report"
 


### PR DESCRIPTION
It's very useful to track whether a report was based on a call request, and if so, which call request it was.

For example, I believe that what's going on in #277 is that we'd like to know which reports were filed based on call requests.

Turned out to be a pretty easy change! Now to figure out how to get it to the QA folks...