### PR TITLE
auth0: Use the same Django group names for staging and prod.

### DIFF
--- a/vaccinate/auth0login/pipeline.py
+++ b/vaccinate/auth0login/pipeline.py
@@ -8,8 +8,14 @@ AUTH0_ROLES_TO_REFLECT = {
     "Reports QA",
     "VIAL data corrections",
 }
+
+AUTH0_ROLES_TO_LOCAL_GROUP = {}
 if settings.STAGING:
-    AUTH0_ROLES_TO_REFLECT = {name + " STAGING" for name in AUTH0_ROLES_TO_REFLECT}
+    AUTH0_ROLES_TO_LOCAL_GROUP = {
+        name + " STAGING": name for name in AUTH0_ROLES_TO_REFLECT
+    }
+else:
+    AUTH0_ROLES_TO_LOCAL_GROUP = {name: name for name in AUTH0_ROLES_TO_REFLECT}
 
 
 def provide_admin_access_based_on_auth0_role(backend, user, response, *args, **kwargs):
@@ -17,17 +23,18 @@ def provide_admin_access_based_on_auth0_role(backend, user, response, *args, **k
         users_roles = kwargs.get("details", {}).get("roles", {}) or []
         groups = {
             name: Group.objects.get_or_create(name=name)[0]
-            for name in AUTH0_ROLES_TO_REFLECT
+            for name in AUTH0_ROLES_TO_LOCAL_GROUP.values()
         }
         should_be_staff = any(
-            auth0_role in users_roles for auth0_role in AUTH0_ROLES_TO_REFLECT
+            auth0_role in users_roles
+            for auth0_role in AUTH0_ROLES_TO_LOCAL_GROUP.keys()
         )
         if should_be_staff != user.is_staff:
             user.is_staff = should_be_staff
             user.save()
         # Add user to groups if necessary:
-        for auth0_role in AUTH0_ROLES_TO_REFLECT:
-            group = groups[auth0_role]
+        for auth0_role, local_group in AUTH0_ROLES_TO_LOCAL_GROUP.items():
+            group = groups[local_group]
             if auth0_role in users_roles:
                 group.user_set.add(user)
             else:


### PR DESCRIPTION
When we sync prod -> staging, it did not have Django groups for,
e.g. `VIAL super-user STAGING` only `VIAL super-user`.  As such, when
users logged into VIAL, they found themselves without their elevated
permissions.

Rather than maintain separate a STAGING *and* non-STAGING group in
staging and procution, map the auth0 roles into groups that have a
consistent name between production and staging.  This means that the
"VIAL super-user STAGING" role will grant the same permissions on staging
as "VIAL super-user" does on production after a sync.

Ref #403.