### PR TITLE
Export data to Mapbox with Zoom Elements

### DIFF
--- a/vaccinate/api/views.py
+++ b/vaccinate/api/views.py
@@ -984,7 +984,8 @@ def export_mapbox(request):
                 {
                     "public_notes": [None] * 6 + [report.public_notes],
                     "appointment_method": report.appointment_tag.name,
-                    "appointment_details": [None] * 6 + [report.full_appointment_details(location)],
+                    "appointment_details": [None] * 6
+                    + [report.full_appointment_details(location)],
                     "latest_contact": report.created_at.isoformat(),
                 }
             )


### PR DESCRIPTION
As part of https://github.com/CAVaccineInventory/vaccinatethestates/pull/130, we've wanted to start excluding some data in lower zoom levels (i.e. zoomed out). Why? Mapbox gives us a hard limit of 500kb per tile. All the data of each point counts against that, meaning the tiles in the lower zoom levels are dropping a lot of points. This PR aims to let us use [Mapbox Zoom Elements](https://docs.mapbox.com/mapbox-tiling-service/reference/#zoom-element) to drop data per-point from lower zoom level tiles, allowing more points, and having less pop in/out as someone zooms into the map.

Additionally, I'm not a regular python developer, so I'm not sure if using `None` is the ideal here or if there's a simple and nice way to clear up this repetition.