### PR TITLE
Fixes #411: don't fail when links is null.

### DIFF
--- a/vaccinate/api/test-data/importSourceLocations/004-null-links.json
+++ b/vaccinate/api/test-data/importSourceLocations/004-null-links.json
@@ -1,0 +1,49 @@
+{
+  "source_uid": "7382088",
+  "source_name": "vaccinespotter",
+  "name": "Rite Aid",
+  "latitude": 33.4962,
+  "longitude": -117.663,
+  "import_json": {
+    "id": "vaccinespotter:7382088",
+    "name": "Rite Aid",
+    "address": {
+      "street1": "32121 Camino Capistrano",
+      "city": "San Juan Capistrano",
+      "state": "CA",
+      "zip": "92675"
+    },
+    "location": {
+      "latitude": 33.4962,
+      "longitude": -117.663
+    },
+    "booking": {
+      "website": "https://www.riteaid.com/pharmacy/covid-qualifier"
+    },
+    "availability": {
+      "appointments": false
+    },
+    "parent_organization": {
+      "id": "rite_aid",
+      "name": "Rite Aid"
+    },
+    "links": null,
+    "source": {
+      "source": "vaccinespotter",
+      "id": "7382088",
+      "fetched_from_uri": "https://www.vaccinespotter.org/api/v0/states/CA.json",
+      "fetched_at": "2021-04-06T20:17:55.148+00:00",
+      "published_at": "2021-04-06T20:17:55.148+00:00",
+      "data": {
+        "geometry": {
+          "type": "Point",
+          "coordinates": [
+            -117.663,
+            33.4962
+          ]
+        },
+        "id": 7382088
+      }
+    }
+  }
+}

--- a/vaccinate/api/test_import_source_locations.py
+++ b/vaccinate/api/test_import_source_locations.py
@@ -63,7 +63,13 @@ def test_import_location(client, api_key, json_path):
 
     assert response.status_code == 200
     assert SourceLocation.objects.count() == 1
-    assert ConcordanceIdentifier.objects.count() == 2
+    if (
+        "links" in fixture["import_json"]
+        and fixture["import_json"]["links"] is not None
+    ):
+        assert ConcordanceIdentifier.objects.count() == len(
+            fixture["import_json"]["links"]
+        )
     json_response = response.json()
     assert "created" in json_response
     assert len(json_response["created"]) == 1

--- a/vaccinate/api/views.py
+++ b/vaccinate/api/views.py
@@ -684,7 +684,7 @@ def import_source_locations(request, on_request_logged):
         )
 
         import_json = record["import_json"]
-        if "links" in import_json:
+        if "links" in import_json and import_json["links"] is not None:
             for link in import_json["links"]:
                 identifier, _ = ConcordanceIdentifier.objects.get_or_create(
                     authority=link["authority"], identifier=link["id"]


### PR DESCRIPTION
Fixes a 500 when `/api/importSourceLocations` used `links: null`.