### PR TITLE
Remove Zoom Element code

### DIFF
--- a/vaccinate/api/views.py
+++ b/vaccinate/api/views.py
@@ -961,10 +961,6 @@ def export_mapbox(request):
 
     post_data = ""
     for location in locations.all():
-        # What are these leading `[None]` elements? Since some fields can be
-        # big, we use Mapbox "zoom elements" to only include them in tiles that
-        # are of a specific zoom level and higher (i.e. more zoomed in),
-        # allowing us to have more points per tile
         properties = {
             "id": location.public_id,
             "name": location.name,


### PR DESCRIPTION
This effectively reverts https://github.com/CAVaccineInventory/vial/pull/408.

In https://github.com/CAVaccineInventory/vaccinatethestates/pull/130, we were experimenting with Mapbox Zoom Elements to help decrease the size of points so we could include more of them at lower zoom levels (i.e. zoomed out) so that points wouldn't pop in and out as much when users zoomed in.

However, we ended up going down a different path and this zoom element stuff isn't necessary. While it doesn't hurt, it also isn't used at all and is confusing. This cleans it up!