### PR TITLE
Save source as concordance on source location.

### DIFF
--- a/vaccinate/api/test_import_source_locations.py
+++ b/vaccinate/api/test_import_source_locations.py
@@ -67,7 +67,8 @@ def test_import_location(client, api_key, json_path):
         "links" in fixture["import_json"]
         and fixture["import_json"]["links"] is not None
     ):
-        assert ConcordanceIdentifier.objects.count() == len(
+        # Add one for the source concordance
+        assert ConcordanceIdentifier.objects.count() == 1 + len(
             fixture["import_json"]["links"]
         )
     json_response = response.json()
@@ -81,6 +82,12 @@ def test_import_location(client, api_key, json_path):
     assert source_location.longitude == fixture["import_json"]["location"]["longitude"]
     assert source_location.import_json == fixture["import_json"]
     # TODO add more assertions about fields later
+
+    # Source concordance must be associated with concordances
+    source_concordance = ConcordanceIdentifier.objects.get(
+        authority=fixture["source_name"], identifier=fixture["source_uid"]
+    )
+    assert source_concordance in source_location.concordances.all()
 
     if (
         "match" in fixture

--- a/vaccinate/api/views.py
+++ b/vaccinate/api/views.py
@@ -417,12 +417,20 @@ def import_source_locations(request, on_request_logged):
         )
 
         import_json = record["import_json"]
-        if "links" in import_json and import_json["links"] is not None:
-            for link in import_json["links"]:
-                identifier, _ = ConcordanceIdentifier.objects.get_or_create(
-                    authority=link["authority"], identifier=link["id"]
-                )
-                identifier.source_locations.add(source_location)
+
+        links = (
+            list(import_json.get("links"))
+            if import_json.get("links") is not None
+            else []
+        )
+        # Always use the (source_name, source_uid) as a concordance
+        links.append({"authority": record["source_name"], "id": record["source_uid"]})
+
+        for link in links:
+            identifier, _ = ConcordanceIdentifier.objects.get_or_create(
+                authority=link["authority"], identifier=link["id"]
+            )
+            identifier.source_locations.add(source_location)
 
         if "match" in record and record["match"]["action"] == "new":
             matched_location = build_location_from_source_location(source_location)


### PR DESCRIPTION
We would like to use the source of a source location as a concordance, e.g., when searching for this location again.

Refs #422.