### PR TITLE
#463 truncate long urls in Vial > Admin > Reports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@ __pycache__
 .vscode
 .DS_Store
 .env
+venv
 /vaccinate/staticfiles/

--- a/vaccinate/core/admin.py
+++ b/vaccinate/core/admin.py
@@ -12,6 +12,7 @@ from django.urls import reverse
 from django.utils import dateformat, timezone
 from django.utils.html import escape, format_html
 from django.utils.safestring import mark_safe
+from django.utils.text import Truncator
 from reversion.models import Revision, Version
 from reversion_compare.admin import CompareVersionAdmin
 
@@ -1020,7 +1021,9 @@ class ReportAdmin(DynamicListDisplayMixin, admin.ModelAdmin):
             raw_details.startswith("http://") or raw_details.startswith("https://")
         ):
             details = format_html(
-                '<a target="_blank" href="{}">{}</a>', raw_details, raw_details
+                '<a target="_blank" href="{}">{}</a>',
+                raw_details,
+                Truncator(raw_details).chars(75),
             )
         else:
             details = escape(raw_details or "")


### PR DESCRIPTION
- I wasn't able to test this locally, because there is no way to successfully create a report on my local Django instance (per conversations on Discord)
- Why I used `django.utils.text.Truncator`: because it's available, and it's better than hand-rolling truncation logic, which involves tedious code to conditionally add ellipses, etc. I hope it does the right thing!