### PR TITLE
Fix race condition in blob uploads by not using smart_open.

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -117,6 +117,3 @@ timezonefinder[numba]
 
 # Test data
 factory_boy
-
-# Streaming GCS uploads
-smart_open[gcs]

--- a/requirements.txt
+++ b/requirements.txt
@@ -289,9 +289,7 @@ google-cloud-secret-manager==2.4.0 \
 google-cloud-storage==1.38.0 \
     --hash=sha256:162011d66f64b8dc5d7936609a5daf0066cc521231546aea02c126a5559446c4 \
     --hash=sha256:69499560ec8234339ce831704419a2288c409a422f6e9ed1facc9345412ee637
-    # via
-    #   -r requirements.in
-    #   smart-open
+    # via -r requirements.in
 google-crc32c==1.1.2 \
     --hash=sha256:0ae3cf54e0d4d83c8af1afe96fc0970fbf32f1b29275f3bfd44ce25c4b622a2b \
     --hash=sha256:0dd9b61d0c63043b013349c9ec8a83ec2b05c96410c5bc257da5d0de743fc171 \
@@ -929,10 +927,6 @@ six==1.15.0 \
     #   python-jose
     #   requests-mock
     #   social-auth-app-django
-smart-open[gcs]==5.0.0 \
-    --hash=sha256:02e5e02207d955a1f9fd924c37900ac272536bd24393ae731b6945d4f766015f \
-    --hash=sha256:ed310ac51a797051b42f9437a566ac8149a3abf8c80ab994a8bd92d96fb7cf44
-    # via -r requirements.in
 sniffio==1.2.0 \
     --hash=sha256:471b71698eac1c2112a40ce2752bb2f4a4814c22a54a3eed3676bc0f5ca9f663 \
     --hash=sha256:c4666eecec1d3f50960c6bdf61ab7bc350648da6c126e3cf6898d8cd4ddcd3de


### PR DESCRIPTION
Before, encoding metadata would be set after blob creation resulting in a
small window when the header wouldn't be served, resulting in raw gzip bytes
being served.

This was the only use of smart_open, so remove from requirements.