### PR TITLE
Move and collapse fields behind heading on locations and reports

### DIFF
--- a/vaccinate/core/admin.py
+++ b/vaccinate/core/admin.py
@@ -583,6 +583,10 @@ class LocationAdmin(DynamicListDisplayMixin, CompareVersionAdmin):
         "dn_skip_report_count",
         "dn_yes_report_count",
         "matched_source_locations",
+        "vaccines_offered",
+        "accepts_appointments",
+        "accepts_walkins",
+        "public_notes",
     )
 
     def save_model(self, request, obj, form, change):
@@ -851,6 +855,7 @@ class ReportAdmin(DynamicListDisplayMixin, admin.ModelAdmin):
         "reported_by__name",
         "reported_by__display_name",
     )
+
     list_display = (
         "created_id_deleted",
         "location_link",
@@ -913,6 +918,9 @@ class ReportAdmin(DynamicListDisplayMixin, admin.ModelAdmin):
         "airtable_json",
         "reporter_qa_summary",
         "location_reports_history",
+        "hours",
+        "full_address",
+        "website",
     )
     inlines = [ReportReviewNoteInline]
     deliberately_omitted_from_fieldsets = ("location", "reported_by")


### PR DESCRIPTION
https://github.com/CAVaccineInventory/vial/issues/609#issuecomment-849922947

Moves and a bunch of fields at the end of a location or report form, under the heading "{Name} data for debugging" and makes these fields read-only.

<img width="795" alt="Screen Shot 2021-05-28 at 3 27 24 PM" src="https://user-images.githubusercontent.com/6485006/120047384-4dd3f400-bfc9-11eb-90bc-85e086c8ff17.png">
<img width="795" alt="Screen Shot 2021-05-28 at 3 28 55 PM" src="https://user-images.githubusercontent.com/6485006/120047421-6e03b300-bfc9-11eb-8c4f-89b2d1b3a02f.png">
